### PR TITLE
Add sample Magento blog article module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# magento_article
-This is magento extension of articles
+# Magento Blog Article Module
+This repository contains a sample Magento 2 module that adds basic blog article functionality.
+
+## Installation
+1. Copy the `app` directory into your Magento installation root.
+2. Run `php bin/magento setup:upgrade` to register the module.
+
+After installation, navigate to `/blog/index/index` in your store frontend to view the example page.
+
+## Module Overview
+The module is registered under the name `ThirdParty_BlogArticle` and provides a starting point for building blog features in a Magento store.

--- a/app/code/ThirdParty/BlogArticle/Block/Article.php
+++ b/app/code/ThirdParty/BlogArticle/Block/Article.php
@@ -1,0 +1,10 @@
+<?php
+namespace ThirdParty\BlogArticle\Block;
+
+class Article extends \Magento\Framework\View\Element\Template
+{
+    public function getHelloMessage()
+    {
+        return __('Hello Blog Article');
+    }
+}

--- a/app/code/ThirdParty/BlogArticle/Controller/Index/Index.php
+++ b/app/code/ThirdParty/BlogArticle/Controller/Index/Index.php
@@ -1,0 +1,20 @@
+<?php
+namespace ThirdParty\BlogArticle\Controller\Index;
+
+class Index extends \Magento\Framework\App\Action\Action
+{
+    protected $resultPageFactory;
+
+    public function __construct(
+        \Magento\Framework\App\Action\Context $context,
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+    ) {
+        $this->resultPageFactory = $resultPageFactory;
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        return $this->resultPageFactory->create();
+    }
+}

--- a/app/code/ThirdParty/BlogArticle/etc/frontend/routes.xml
+++ b/app/code/ThirdParty/BlogArticle/etc/frontend/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="standard">
+        <route id="blog" frontName="blog">
+            <module name="ThirdParty_BlogArticle" />
+        </route>
+    </router>
+</config>

--- a/app/code/ThirdParty/BlogArticle/etc/module.xml
+++ b/app/code/ThirdParty/BlogArticle/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="ThirdParty_BlogArticle" setup_version="1.0.0"/>
+</config>

--- a/app/code/ThirdParty/BlogArticle/registration.php
+++ b/app/code/ThirdParty/BlogArticle/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'ThirdParty_BlogArticle',
+    __DIR__
+);

--- a/app/code/ThirdParty/BlogArticle/view/frontend/layout/blog_index_index.xml
+++ b/app/code/ThirdParty/BlogArticle/view/frontend/layout/blog_index_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="ThirdParty\\BlogArticle\\Block\\Article" name="blog.article" template="ThirdParty_BlogArticle::article.phtml" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/ThirdParty/BlogArticle/view/frontend/templates/article.phtml
+++ b/app/code/ThirdParty/BlogArticle/view/frontend/templates/article.phtml
@@ -1,0 +1,1 @@
+<p><?php echo $block->getHelloMessage(); ?></p>


### PR DESCRIPTION
## Summary
- provide basic Magento 2 module skeleton for blog articles
- document installation steps

## Testing
- `apt-get update`
- `apt-get install -y php-cli`
- `find app -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_6863987024e883248bdb925939902408