### PR TITLE
Add PHPUnit test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # magento_article
 This is magento extension of articles
+
+## Contributing
+Run the test suite using:
+
+```
+vendor/bin/phpunit -c tests/phpunit.xml
+```

--- a/tests/LicenseTest.php
+++ b/tests/LicenseTest.php
@@ -1,0 +1,12 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LicenseTest extends TestCase
+{
+    public function testLicenseFileExistsAndNotEmpty()
+    {
+        $licensePath = __DIR__ . '/../LICENSE';
+        $this->assertFileExists($licensePath);
+        $this->assertNotEmpty(trim(file_get_contents($licensePath)));
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>./</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- set up PHPUnit config in tests/phpunit.xml
- add LicenseTest ensuring `LICENSE` exists and isn't empty
- document how to run the tests

## Testing
- `vendor/bin/phpunit -c tests/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa19cedc83249af029e4cb8932aa