### PR TITLE
Add GitHub Actions CI/CD workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mbstring, intl, dom
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      - name: Run tests
+        run: ./vendor/bin/phpunit --configuration tests/phpunit.xml
+      - name: Package module
+        run: zip -r module.zip app
+      - name: Deploy to server
+        if: github.ref == 'refs/heads/main'
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          TARGET_DIR: ${{ secrets.DEPLOY_PATH }}
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          echo "$SSH_KEY" > deploy_key
+          chmod 600 deploy_key
+          scp -i deploy_key module.zip "$USER@$HOST:$TARGET_DIR/"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ composer install
    ```
 3. Set a package name in `composer.json` and push a version tag to GitHub.
    The package will appear under the repository's **Packages** tab.
+
+## CI/CD Pipeline
+This repository ships with a GitHub Actions workflow that installs dependencies, runs the unit tests, packages the `app` directory and optionally deploys it using SSH.
+To enable deployment set the `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH` and `DEPLOY_SSH_KEY` secrets in your repository settings.
+


### PR DESCRIPTION
## Summary
- set up a GitHub Actions workflow to install dependencies, run PHPUnit, package and deploy
- document new CI/CD pipeline in the README

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68660ab9a36c83248ea7fa74055e9ace