### PR TITLE
Add admin page for blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a sample Magento 2 module that adds basic blog article 
 2. Run `php bin/magento setup:upgrade` to register the module and create the blog table.
 
 After installation, navigate to `/blog/index/index` in your store frontend to view the posts stored in the database.
+An admin listing page is available under **Content > Blog Posts** in the Magento backend.
 
 ## Module Overview
 The module is registered under the name `ThirdParty_BlogArticle` and provides a starting point for building blog features in a Magento store. It creates a `thirdparty_blogarticle_post` table on installation and displays all posts using the `Article` block.

--- a/app/code/ThirdParty/BlogArticle/Block/Adminhtml/Post.php
+++ b/app/code/ThirdParty/BlogArticle/Block/Adminhtml/Post.php
@@ -1,0 +1,24 @@
+<?php
+namespace ThirdParty\BlogArticle\Block\Adminhtml;
+
+class Post extends \Magento\Backend\Block\Template
+{
+    /**
+     * @var \ThirdParty\BlogArticle\Model\ResourceModel\Post\CollectionFactory
+     */
+    protected $collectionFactory;
+
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \ThirdParty\BlogArticle\Model\ResourceModel\Post\CollectionFactory $collectionFactory,
+        array $data = []
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        parent::__construct($context, $data);
+    }
+
+    public function getPosts()
+    {
+        return $this->collectionFactory->create();
+    }
+}

--- a/app/code/ThirdParty/BlogArticle/Controller/Adminhtml/Post/Index.php
+++ b/app/code/ThirdParty/BlogArticle/Controller/Adminhtml/Post/Index.php
@@ -1,0 +1,28 @@
+<?php
+namespace ThirdParty\BlogArticle\Controller\Adminhtml\Post;
+
+class Index extends \Magento\Backend\App\Action
+{
+    const ADMIN_RESOURCE = 'ThirdParty_BlogArticle::posts';
+
+    /**
+     * @var \Magento\Framework\View\Result\PageFactory
+     */
+    protected $resultPageFactory;
+
+    public function __construct(
+        \Magento\Backend\App\Action\Context $context,
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+    ) {
+        $this->resultPageFactory = $resultPageFactory;
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('ThirdParty_BlogArticle::posts');
+        $resultPage->getConfig()->getTitle()->prepend(__('Blog Posts'));
+        return $resultPage;
+    }
+}

--- a/app/code/ThirdParty/BlogArticle/etc/acl.xml
+++ b/app/code/ThirdParty/BlogArticle/etc/acl.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <resources>
+        <resource id="Magento_Backend::admin">
+            <resource id="ThirdParty_BlogArticle::posts" title="Blog Posts" sortOrder="10" />
+        </resource>
+    </resources>
+</acl>

--- a/app/code/ThirdParty/BlogArticle/etc/adminhtml/menu.xml
+++ b/app/code/ThirdParty/BlogArticle/etc/adminhtml/menu.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Menu/etc/menu.xsd">
+    <menu>
+        <add id="ThirdParty_BlogArticle::posts" title="Blog Posts" module="ThirdParty_BlogArticle" sortOrder="100" parent="Magento_Backend::content" resource="ThirdParty_BlogArticle::posts"/>
+    </menu>
+</config>

--- a/app/code/ThirdParty/BlogArticle/etc/adminhtml/routes.xml
+++ b/app/code/ThirdParty/BlogArticle/etc/adminhtml/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="blogarticle" frontName="blogarticle">
+            <module name="ThirdParty_BlogArticle" />
+        </route>
+    </router>
+</config>

--- a/app/code/ThirdParty/BlogArticle/view/adminhtml/layout/blogarticle_post_index.xml
+++ b/app/code/ThirdParty/BlogArticle/view/adminhtml/layout/blogarticle_post_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="ThirdParty\\BlogArticle\\Block\\Adminhtml\\Post" name="blogarticle.post.list" template="ThirdParty_BlogArticle::post/list.phtml" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/ThirdParty/BlogArticle/view/adminhtml/templates/post/list.phtml
+++ b/app/code/ThirdParty/BlogArticle/view/adminhtml/templates/post/list.phtml
@@ -1,0 +1,9 @@
+<?php /** @var \ThirdParty\BlogArticle\Block\Adminhtml\Post $block */ ?>
+<?php foreach ($block->getPosts() as $post): ?>
+    <div class="blog-post">
+        <h2><?php echo $block->escapeHtml($post->getTitle()); ?></h2>
+        <div class="content">
+            <?php echo $post->getContent(); ?>
+        </div>
+    </div>
+<?php endforeach; ?>


### PR DESCRIPTION
## Summary
- provide simple backend controller, block and layout
- register admin routes, menu and ACL
- note new admin page in README

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68668179d264832498d26dfa6ee9deb1