### PR TITLE
Add dummy-data driven PHPUnit test runner and sample fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ composer install
 ./vendor/bin/phpunit --configuration tests/phpunit.xml
 ```
 
+Run a specific PHPUnit test file with a dummy JSON input file:
+
+```bash
+./tests/run_with_dummy_data.sh tests/DummyDataInputTest.php tests/dummy_posts.json
+```
+
+`run_with_dummy_data.sh` passes the JSON file path through the `DUMMY_DATA_FILE` environment variable so your test can load fixture-like dummy input dynamically.
+
+
 ## Publishing to GitHub Packages
 1. Generate a personal access token (PAT) with `write:packages` and `read:packages` permissions.
 2. Configure Composer to use your PAT:

--- a/tests/DummyDataInputTest.php
+++ b/tests/DummyDataInputTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class DummyDataInputTest extends TestCase
+{
+    public function testDummyDataFileCanBeReadAndContainsRequiredKeys(): void
+    {
+        $dummyDataFile = getenv('DUMMY_DATA_FILE');
+
+        if ($dummyDataFile === false || $dummyDataFile === '') {
+            $this->markTestSkipped('Set DUMMY_DATA_FILE to run dummy data input test.');
+        }
+        $this->assertFileExists($dummyDataFile);
+
+        $json = file_get_contents($dummyDataFile);
+        $this->assertNotFalse($json, 'Failed to read dummy data file.');
+
+        $data = json_decode($json, true);
+        $this->assertIsArray($data, 'Dummy data file must contain a JSON array.');
+        $this->assertNotEmpty($data, 'Dummy data array must not be empty.');
+
+        foreach ($data as $index => $post) {
+            $this->assertIsArray($post, sprintf('Item %d must be an object.', $index));
+            $this->assertArrayHasKey('title', $post);
+            $this->assertArrayHasKey('content', $post);
+            $this->assertNotSame('', trim((string) $post['title']));
+            $this->assertNotSame('', trim((string) $post['content']));
+        }
+    }
+}

--- a/tests/dummy_posts.json
+++ b/tests/dummy_posts.json
@@ -1,0 +1,10 @@
+[
+  {
+    "title": "Welcome to the blog",
+    "content": "This is dummy content for the first post."
+  },
+  {
+    "title": "Second sample post",
+    "content": "This post is used to test JSON dummy data input."
+  }
+]

--- a/tests/run_with_dummy_data.sh
+++ b/tests/run_with_dummy_data.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <phpunit-test-file> <dummy-data-json-file>"
+  exit 1
+fi
+
+TEST_FILE="$1"
+DUMMY_FILE="$2"
+
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "Test file not found: $TEST_FILE"
+  exit 1
+fi
+
+if [[ ! -f "$DUMMY_FILE" ]]; then
+  echo "Dummy data file not found: $DUMMY_FILE"
+  exit 1
+fi
+
+DUMMY_DATA_FILE="$DUMMY_FILE" ./vendor/bin/phpunit --configuration tests/phpunit.xml "$TEST_FILE"


### PR DESCRIPTION
### Motivation
- Provide a simple way to run a specific PHPUnit test file using an external JSON fixture so tests can validate data-driven behavior without changing the main suite.

### Description
- Add `tests/run_with_dummy_data.sh` which accepts a test file and a JSON fixture file, sets `DUMMY_DATA_FILE`, and runs the specified test with PHPUnit.
- Add `tests/DummyDataInputTest.php` which reads `DUMMY_DATA_FILE`, validates it is a non-empty JSON array, and asserts each item contains `title` and `content`, skipping the test when `DUMMY_DATA_FILE` is not set.
- Add sample fixture `tests/dummy_posts.json` containing two example posts.
- Update `README.md` with usage instructions for `./tests/run_with_dummy_data.sh`.

### Testing
- Ran `composer install` to install dev dependencies and it completed successfully.
- Ran `./tests/run_with_dummy_data.sh tests/DummyDataInputTest.php tests/dummy_posts.json` which exercised the new test and completed under PHPUnit.
- Ran the full PHPUnit suite via `./vendor/bin/phpunit --configuration tests/phpunit.xml` and the suite completed with all tests passing while one test was intentionally skipped ("OK, but some tests were skipped!"; Tests: 3, Assertions: 4, Skipped: 1).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf3ab76ec8324916cd4bc7921af72)